### PR TITLE
✨ Allow for customized event payloads

### DIFF
--- a/src/types/model/events/end_event.ts
+++ b/src/types/model/events/end_event.ts
@@ -57,7 +57,7 @@ export class EndEvent extends Event {
   public signalEventDefinition?: SignalEventDefinition;
   public terminateEventDefinition?: TerminateEventDefinition;
   /**
-   * When using a SignalEndEvent or MessageEndEvent, this property can hold a
+   * When sending messages or signals, this property can hold a
    * definition for a payload to send with the event.
    *
    * Use this, if you do not want to use the current ProcessToken as event

--- a/src/types/model/events/end_event.ts
+++ b/src/types/model/events/end_event.ts
@@ -56,5 +56,12 @@ export class EndEvent extends Event {
   public messageEventDefinition?: MessageEventDefinition;
   public signalEventDefinition?: SignalEventDefinition;
   public terminateEventDefinition?: TerminateEventDefinition;
-
+  /**
+   * When using a SignalEndEvent or MessageEndEvent, this property can hold a
+   * definition for a payload to send with the event.
+   *
+   * Use this, if you do not want to use the current ProcessToken as event
+   * payload.
+   */
+  public inputValues?: any;
 }

--- a/src/types/model/events/intermediate_throw_event.ts
+++ b/src/types/model/events/intermediate_throw_event.ts
@@ -53,4 +53,12 @@ export class IntermediateThrowEvent extends Event {
    * to throw.
    */
   public signalEventDefinition?: SignalEventDefinition;
+  /**
+   * When sending messages or signals, this property can hold a
+   * definition for a payload to send with the event.
+   *
+   * Use this, if you do not want to use the current ProcessToken as event
+   * payload.
+   */
+  public inputValues?: any;
 }


### PR DESCRIPTION
**Changes:**

Add optional `inputValues` property to `EndEvent` and `IntermediateThrowEvent` models.

This allows a user to provide a customized payload with events that throw signals and messages.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/296

PR: #4

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).